### PR TITLE
Add opt-in/out

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -10,6 +10,7 @@
             "crypto"
         ],
         "player_role": 1234567890,
+        "optout_player_role": 1234567890,
         "admin_role": 1234567890,
         "transcript_channel": 1234567890,
         "loading_emoji": "<a:name:1234567890>"

--- a/organizers_bot/bot.py
+++ b/organizers_bot/bot.py
@@ -92,8 +92,6 @@ def setup():
                 guild_ids=[config.bot.guild])
     @require_role(config.mgmt.player_role)
     async def opt_out(ctx: discord_slash.SlashContext):
-        await ctx.defer()
-
         member = ctx.author
         guild = ctx.guild
 
@@ -108,14 +106,10 @@ def setup():
             await ctx.send("You are already opted out.", hidden=True)
             return
 
-        try:
-            await member.add_roles(optout_role, reason=f"User opted out via /optout command")
-            if player_role in member.roles:
-                await member.remove_roles(player_role, reason=f"User opted out via /optout command")
+        await member.add_roles(optout_role, reason=f"User opted out via /optout command")
+        await member.remove_roles(player_role, reason=f"User opted out via /optout command")
 
-            await ctx.send(f"You have successfully opted out.")
-        except:
-            await ctx.send("Error: I don't have permissions? to manage roles. Please contact an admin.", hidden=True)
+        await ctx.send(f"You have successfully opted out.")
 
 
     @slash.slash(name="optin",
@@ -123,8 +117,6 @@ def setup():
                 guild_ids=[config.bot.guild])
     @require_role(config.mgmt.optout_player_role)
     async def opt_in(ctx: discord_slash.SlashContext):
-        await ctx.defer() # Acknowledge interaction
-
         member = ctx.author
         guild = ctx.guild
 
@@ -135,21 +127,12 @@ def setup():
             await ctx.send("Error: roles are not configured correctly. Please contact an admin.", hidden=True)
             return
 
-        if optout_role not in member.roles:
-            await ctx.send("You are already opted in.", hidden=True)
-            return
+        if player_role not in member.roles:
+            await member.add_roles(player_role, reason=f"User opted in via /optout command")
 
-        try:
-            if player_role not in member.roles:
-                await member.add_roles(player_role, reason=f"User opted in via /optout command")
-            if optout_role in member.roles:
-                await member.remove_roles(optout_role, reason=f"User opted in via /optout command")
+        await member.remove_roles(optout_role, reason=f"User opted in via /optout command")
 
-            await ctx.send(f"Welcome back!")
-
-        except:
-            await ctx.send("Error: I don't have permission? to manage roles. Please contact an admin.", hidden=True)
-
+        await ctx.send(f"Welcome back!")
 
     @slash.slash(name="ctfnote_fixup_channel",
                  description="Use this if you need to set/change the ctfnote id of the current channel after the channel creation.",

--- a/organizers_bot/config.py
+++ b/organizers_bot/config.py
@@ -13,6 +13,7 @@ class BotConfig:
 class ManagementConfig:
     categories: list[str]
     player_role: int
+    optout_player_role: int
     admin_role: int
     transcript_channel: int
     loading_emoji: str
@@ -41,6 +42,7 @@ def load(filename: pathlib.Path):
         mgmt = ManagementConfig(
                 conf['mgmt']['categories'],
                 conf['mgmt']['player_role'],
+                conf['mgmt']['optout_player_role'],
                 conf['mgmt']['admin_role'],
                 conf['mgmt']['transcript_channel'],
                 conf['mgmt']['loading_emoji']


### PR DESCRIPTION
Allow players to opt-out of CTF participation.
To add this, create a new opt-out role, add it to the current config file.

The command will switch out the player role for this new role and switch back on opt in (And post to audit log / current command channel).